### PR TITLE
added `log` method to `GlobalVariables`

### DIFF
--- a/cea/demand.py
+++ b/cea/demand.py
@@ -90,7 +90,7 @@ def demand_calculation(locator, gv):
                            prop_geometry.ix[building], prop_HVAC_result.ix[building], prop_RC_model.ix[building],
                            prop_age.ix[building], Solar.ix[building], locator.get_demand_results_folder(), schedules,
                            list_uses, T_ext, T_ext_max, RH_ext, T_ext_min, locator.get_temporary_folder(), gv, 0, 0)
-        print 'Building No. ' + str(counter + 1) + ' completed out of ' + str(num_buildings)
+        gv.log('Building No. %(bno)i completed out of %(btot)i', bno=counter + 1, btot=num_buildings)
         counter += 1
 
     # get total file
@@ -108,7 +108,7 @@ def demand_calculation(locator, gv):
             df = df.append(df2, ignore_index=True)
     df.to_csv(locator.get_total_demand(), index=False, float_format='%.2f')
 
-    print 'finished'
+    gv.log('finished')
 
 
 def get_schedules(locator, list_uses):

--- a/cea/globalvar.py
+++ b/cea/globalvar.py
@@ -53,3 +53,6 @@ class GlobalVariables(object):
 
         # here is where we plug in the models to use for calculations
         self.models = {'calc-thermal-loads': functions.CalcThermalLoads}
+
+    def log(self, msg, **kwargs):
+        print msg % kwargs

--- a/cea/graphs.py
+++ b/cea/graphs.py
@@ -14,7 +14,7 @@ import pandas as pd
 import inputlocator
 
 
-def graphs_demand(locator, analysis_fields):
+def graphs_demand(locator, analysis_fields, gv):
     """
     algorithm to print graphs in PDF concerning the dynamics of each and all buildings
 
@@ -61,7 +61,7 @@ def graphs_demand(locator, analysis_fields):
         plt.clf()
         plt.close()
 
-        print 'Building No. ' + str(counter + 1) + ' completed out of ' + str(num_buildings)
+        gv.log('Building No. %(bno)i completed out of %(btot)i', bno=counter+1, btot=num_buildings)
         counter += 1
 
 
@@ -69,11 +69,12 @@ def test_graph_demand():
     # HINTS FOR ARCGIS INTERFACE:
     # the user should see all the column names of the total_demands.csv
     # the user can select a maximum of 4 of those column names to graph (analysis fields!
-    #analysis_fields = ["Ealf_kWh", "Qhsf_kWh", "Qwwf_kWh", "Qcsf_kWh"]
-    analysis_fields = [u'Af_m2', u'Tscs0_C', u'Ef_MWhyr', u'mcpcs0_kWC']
+    analysis_fields = ["Ealf_kWh", "Qhsf_kWh", "Qwwf_kWh", "Qcsf_kWh"]
 
     locator = inputlocator.InputLocator(scenario_path=r'C:\reference-case\baseline')
-    graphs_demand(locator=locator, analysis_fields=analysis_fields)
+    import globalvar
+    gv = globalvar.GlobalVariables()
+    graphs_demand(locator=locator, analysis_fields=analysis_fields, gv=gv)
 
 if __name__ == '__main__':
     test_graph_demand()


### PR DESCRIPTION
Using this technique, it is possible to change the `print` statements in the scripts to `gv.log` and they will print just the same.

BUT: When run from the toolbox, the `log` method can be replaced with the new `add_message` which will use `arcpy.AddMessage` instead: voila! We now have logging in arcgis for long-running tasks!