### PR TITLE
222 check for radiation input in demand script

### DIFF
--- a/cea/GUI/demand_tool.py
+++ b/cea/GUI/demand_tool.py
@@ -1,3 +1,5 @@
+import os
+
 import arcpy
 
 import cea
@@ -49,6 +51,18 @@ class DemandTool(object):
         return
 
     def updateMessages(self, parameters):
+        scenario_path = parameters[0].valueAsText
+        if scenario_path is None:
+            return
+        if not os.path.exists(scenario_path):
+            parameters[0].setErrorMessage('Scenario folder not found: %s' % scenario_path)
+            return
+        import cea.inputlocator
+        locator = cea.inputlocator.InputLocator(scenario_path=scenario_path)
+        if not os.path.exists(locator.get_radiation()):
+            parameters[0].setErrorMessage("No radiation data found for scenario. Run radiation script first.")
+        if not os.path.exists(locator.get_surface_properties()):
+            parameters[0].setErrorMessage("No radiation data found for scenario. Run radiation script first.")
         return
 
     def execute(self, parameters, messages):

--- a/cea/demand/demand_main.py
+++ b/cea/demand/demand_main.py
@@ -7,6 +7,8 @@ Analytical energy demand model algorithm
 from __future__ import division
 
 import multiprocessing as mp
+import os
+
 import pandas as pd
 import time
 
@@ -42,13 +44,13 @@ def demand_calculation(locator, weather_path, gv):
     PARAMETERS
     ----------
     :param locator: An InputLocator to locate input files
-    :type locator: inputlocator.InputLocator
+    :type locator: cea.inputlocator.InputLocator
 
     :param weather_path: A path to the EnergyPlus weather data file (.epw)
     :type weather_path: str
 
     :param gv: A GlobalVariable (context) instance
-    :type gv: globalvar.GlobalVariable
+    :type gv: cea.globalvar.GlobalVariable
 
 
     RETURNS
@@ -81,6 +83,9 @@ def demand_calculation(locator, weather_path, gv):
     B153767T.csv: csv file for every building with hourly demand data
     Total_demand.csv: csv file of yearly demand data per buidling.
     """
+    if not os.path.exists(locator.get_radiation()) or not os.path.exists(locator.get_surface_properties()):
+        raise ValueError("No radiation file found in scenario. Consider running radiation script first.")
+
     t0 = time.clock()
 
     date = pd.date_range(gv.date_start, periods=8760, freq='H')

--- a/tests/test_calc_thermal_loads.py
+++ b/tests/test_calc_thermal_loads.py
@@ -15,7 +15,7 @@ REFERENCE_CASE = r'C:\reference-case-open\baseline'
 class TestCalcThermalLoads(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        if os.environ.has_key('REFERENCE_CASE'):
+        if 'REFERENCE_CASE' in os.environ:
             cls.locator = InputLocator(os.environ['REFERENCE_CASE'])
         else:
             cls.locator = InputLocator(REFERENCE_CASE)

--- a/tests/test_check_for_radiation_input_in_demand_script.py
+++ b/tests/test_check_for_radiation_input_in_demand_script.py
@@ -1,0 +1,55 @@
+import tempfile
+import unittest
+import os
+
+import shutil
+import zipfile
+
+
+class TestCheckForRadiationInputInDemandScript(unittest.TestCase):
+    """
+    Tests to make sure the demand script raises a `ValueError` if applied to a reference case that does not have
+    the radiation script output.
+
+    This fixes the issue #222
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Create a copy of the ninecubes reference case in the temp folder. The ninecubes reference case is
+        in the `../examples` folder as a zip file (`ninecubes.zip`) and has to be extracted first.
+        """
+        ninecubes_src = os.path.join(os.path.dirname(__file__), '..', 'examples', 'ninecubes.zip')
+        ninecubes_dst = os.path.join(tempfile.gettempdir(), 'ninecubes.zip')
+        shutil.copyfile(ninecubes_src, ninecubes_dst)
+        archive = zipfile.ZipFile(ninecubes_dst)
+        archive.extractall(os.path.join(tempfile.gettempdir(), 'ninecubes'))
+
+    @classmethod
+    def tearDownClass(cls):
+        """delete the ninecubes stuff from the temp directory"""
+        os.remove(os.path.join(tempfile.gettempdir(), 'ninecubes.zip'))
+        shutil.rmtree(os.path.join(tempfile.gettempdir(), 'ninecubes'))
+
+    def test_ninecubes_copied(self):
+        """sanity check on `setUpClass`"""
+        self.assertTrue(os.path.exists(r'c:\Users\darthoma\AppData\Local\Temp\ninecubes.zip'))
+        self.assertTrue(os.path.exists(r'c:\Users\darthoma\AppData\Local\Temp\ninecubes'))
+
+    def test_demand_checks_radiation_script(self):
+        import cea.inputlocator
+        import cea.demand.demand_main
+        import cea.globalvar
+
+        locator = cea.inputlocator.InputLocator(os.path.join(tempfile.gettempdir(), 'ninecubes', 'nine cubes'))
+        if os.path.exists(locator.get_radiation()):
+            # scenario contains radiation.csv, remove it for test
+            os.remove(locator.get_radiation())
+        if os.path.exists(locator.get_surface_properties()):
+            # scenario contains properties_surfaces.csv, remove it for test
+            os.remove(locator.get_surface_properties())
+        gv = cea.globalvar.GlobalVariables()
+        weather_path = locator.get_weather('Zug')
+        self.assertRaises(ValueError, cea.demand.demand_main.demand_calculation, locator=locator,
+                          weather_path=weather_path, gv=gv)


### PR DESCRIPTION
How to test: The Jenkins will run the unit test to check the part of the demand script raises the ValueError - but you could run a demand simulation manually (with command line interface) for a scenario without radiation files to check this...

In ArcGIS, run the demand tool for a scenario without radiation files. It should not let you start the simulation, but instead provide an error message ("No radiation data found for scenario. Run radiation script first.")